### PR TITLE
fix/tile-color-swap

### DIFF
--- a/cli/src/main.cpp
+++ b/cli/src/main.cpp
@@ -240,8 +240,8 @@ int main(int argc, char** argv) {
 	// data in tile, not type of tile itself.
 	uint8_t paletteColor[8];
 	paletteColor[0] = 0;
-	paletteColor[int(tetromino::J)] = cli::color::yellow;
-	paletteColor[int(tetromino::L)] = cli::color::blue;
+	paletteColor[int(tetromino::J)] = cli::color::blue;
+	paletteColor[int(tetromino::L)] = cli::color::yellow;
 	paletteColor[int(tetromino::S)] = cli::color::green;
 	paletteColor[int(tetromino::Z)] = cli::color::red;
 	paletteColor[int(tetromino::T)] = cli::color::magenta;

--- a/cli/src/main.cpp
+++ b/cli/src/main.cpp
@@ -68,8 +68,8 @@ public:
 	}
 
 	void tileSwap(const tileSwapEvent& event) {
-		// TODO: provide more information in swap event.
-		repaintField();
+		repaintTileField(event.type, event.location);
+		repaintTileField(event.type, event.locationShadow);
 		repaintPreview();
 		repaintSwap();
 	}

--- a/model/include/model/playground.hpp
+++ b/model/include/model/playground.hpp
@@ -24,7 +24,6 @@ namespace model {
 struct tileSpawnEvent {
 	const tile& type;
 	tileState location, locationShadow;
-	bool disableSwap;
 };
 
 /**

--- a/model/include/model/playground.hpp
+++ b/model/include/model/playground.hpp
@@ -70,7 +70,7 @@ struct tileLockEvent {
  */
 struct tileSwapEvent {
 	const tile& type;
-	tileState location;
+	tileState location, locationShadow;
 };
 
 /**

--- a/model/src/playground.cpp
+++ b/model/src/playground.cpp
@@ -204,6 +204,7 @@ bool playground::swapTile() {
 	const tile* typ = current.getType();
 	const tile* previous = swap;
 	tileState location = current.getState();
+	tileState locationShadow = shadow.getState();
 	current = tilePathFinder();
 	shadow = tilePathFinder();
 	swap = typ;
@@ -211,8 +212,9 @@ bool playground::swapTile() {
 
 	// Dispatch the tile swap event at first.
 	tileSwapEvent swapEvent = {
-		.type     = *typ,
-		.location = location,
+		.type           = *typ,
+		.location       = location,
+		.locationShadow = locationShadow,
 	};
 	dispatch(&playgroundListener::tileSwap, swapEvent);
 

--- a/model/src/playground.cpp
+++ b/model/src/playground.cpp
@@ -14,7 +14,7 @@ namespace hacktile {
 namespace model {
 
 playground::playground(tileGenerator* generator, int numPreviews):
-	f(), generator(generator), swap(nullptr), swapEnabled(false),
+	f(), generator(generator), swap(nullptr), swapEnabled(true),
 	current(), shadow(), preview(new const tile*[numPreviews]),
 	numPreviews(numPreviews), previewCursor(0),
 	state(playgroundState::notStarted) {
@@ -72,7 +72,6 @@ void playground::spawnTile(const tile* typ) {
 			.type           = *current.getType(),
 			.location       = current.getState(),
 			.locationShadow = shadow.getState(),
-			.disableSwap    = false,
 		};
 		dispatch(&playgroundListener::tileSpawn, spawnEvent);
 
@@ -90,15 +89,12 @@ void playground::spawnTile(const tile* typ) {
 	if(f.drop(current, 20, newShadow)) {
 		std::swap(shadow, newShadow);
 	}
-	// TODO: make this a separated model from playgroud.
-	swapEnabled = true;
 
 	// Notify the subscribers about the tile spawn.
 	tileSpawnEvent spawnEvent = {
 		.type           = *current.getType(),
 		.location       = current.getState(),
 		.locationShadow = shadow.getState(),
-		.disableSwap    = false,
 	};
 	dispatch(&playgroundListener::tileSpawn, spawnEvent);
 	return;
@@ -184,6 +180,7 @@ bool playground::hardDrop() {
 	f.lock(current, clear);
 	current = tilePathFinder();
 	shadow = tilePathFinder();
+	swapEnabled = true;
 
 	// Dispatch the tile lock and clear event.
 	tileLockEvent afterEvent = {
@@ -222,10 +219,7 @@ bool playground::swapTile() {
 	// Spawn the previous tile or next tile.
 	if(previous == nullptr)
 		spawnNextTile();
-	else {
-		spawnTile(previous);
-		swapEnabled = false;
-	}
+	else spawnTile(previous);
 	return true;
 }
 


### PR DESCRIPTION
- Fix wrong color of L and J piece.
- Fix the incorrect state while dispatching `tileSwapEvent`.
- Add shadow piece location in `tileSwapEvent`.