### PR TITLE
split steps of initialization of `terminal` into chains of base class

### DIFF
--- a/view/cli/include/view/cli/terminal.hpp
+++ b/view/cli/include/view/cli/terminal.hpp
@@ -88,6 +88,22 @@ struct pos {
 	constexpr pos(int x, int y): x(x), y(y) {}
 };
 
+namespace details {
+struct initialized_terminal {
+	termios terminalMode;
+	int term;
+	initialized_terminal(int term);
+	~initialized_terminal();
+};
+struct new_terminal: initialized_terminal {
+	new_terminal(int term);
+};
+struct clear_screen: new_terminal {
+	clear_screen(int term);
+	~clear_screen();
+};
+}
+
 /**
  * @brief terminal provides interface for other instance
  * classes to manipulate the terminal.
@@ -96,22 +112,7 @@ struct pos {
  * current output style and location, and finally synchronize
  * the update to the player screen.
  */
-class terminal {
-	struct term_initializer final {
-		termios terminalMode;
-		int term;
-		term_initializer(int term);
-		~term_initializer();
-	} initialized_term;
-	struct new_screen_setter final {
-		new_screen_setter(term_initializer &t);
-	} new_screen;
-	struct screen_cleaner final {
-		int term;
-		screen_cleaner(int term);
-		~screen_cleaner();
-	} cleaned_screen;
-	int term;
+class terminal: private details::clear_screen {
 	std::vector<char> buffer;
 	uint8_t foregroundColor, backgroundColor;
 	style currentStyle;

--- a/view/cli/include/view/cli/terminal.hpp
+++ b/view/cli/include/view/cli/terminal.hpp
@@ -97,7 +97,21 @@ struct pos {
  * the update to the player screen.
  */
 class terminal {
-	int term; termios terminalMode;
+	struct term_initializer final {
+		termios terminalMode;
+		int term;
+		term_initializer(int term);
+		~term_initializer();
+	} initialized_term;
+	struct new_screen_setter final {
+		new_screen_setter(term_initializer &t);
+	} new_screen;
+	struct screen_cleaner final {
+		int term;
+		screen_cleaner(int term);
+		~screen_cleaner();
+	} cleaned_screen;
+	int term;
 	std::vector<char> buffer;
 	uint8_t foregroundColor, backgroundColor;
 	style currentStyle;
@@ -105,7 +119,6 @@ class terminal {
 	void appendStyleSequence();
 public:
 	terminal(int term);
-	~terminal();
 	terminal& operator<<(foreground);
 	terminal& operator<<(background);
 	terminal& operator<<(move);


### PR DESCRIPTION
This is more like a proof of concept to move steps of construction and destruction into chains of base class, so each completed initialization will trigger the corresponding destruction when there is any exception etc, thus eliminating the need of `defer`.

When there are multiple steps of initialization, `defer` objects should be made either a class member to remember the ownership (what I did in the first commit), or a stack object used with careful `release` (the original way), but the latter I think is like an emulation of the former... Making these steps chains of base class is just another way to make them sub-objects, and in this way they can also share class members...